### PR TITLE
fix: update mapwize-sdk-react-native

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ This library provides developers with a fully featured and ready to use UI to ad
 MapwizeUI has the following PeerDependencies, you have to include them in order to get MapwizeUI working
 
 ```json
-    "mapwize-sdk-react-native": "^1.1.1"
+    "mapwize-sdk-react-native": "^1.1.2",
     "react-native-webview": "^11.2.4",
     "react-native-safe-area-context": "^3.2.0",
     "react-native-localize": "^2.0.2",
-    "react-native-canvas": "^0.1.37"
+    "react-native-canvas": "^0.1.37",
 ```
 
 You can install everything by running the following command

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -25,10 +25,10 @@ PODS:
   - Mapbox-iOS-SDK (5.9.0):
     - MapboxMobileEvents (= 0.10.2)
   - MapboxMobileEvents (0.10.2)
-  - mapwize-sdk-react-native (1.1.1):
+  - mapwize-sdk-react-native (1.1.2):
     - ManualIndoorLocationProvider
     - MapwizeSDK (= 3.4.5)
-    - React
+    - React-Core
   - MapwizeSDK (3.4.5):
     - IndoorLocation (= 1.0.4)
     - Mapbox-iOS-SDK (~> 5.0)
@@ -379,7 +379,7 @@ SPEC CHECKSUMS:
   ManualIndoorLocationProvider: d88640a41b7ab0208de85e4197e8883afa2520f3
   Mapbox-iOS-SDK: a5915700ec84bc1a7f8b3e746d474789e35b7956
   MapboxMobileEvents: 2bc0ca2eedb627b73cf403258dce2b2fa98074a6
-  mapwize-sdk-react-native: 106fb6dbf48855de68115b2793f35ff9948a8fbf
+  mapwize-sdk-react-native: d6415d8fd68ecc37ba98b2537aa7233b025257b0
   MapwizeSDK: 2e5a21750d6403c4bcfe28f40407853f71d62ed0
   RCTRequired: cec6a34b3ac8a9915c37e7e4ad3aa74726ce4035
   RCTTypeSafety: 93006131180074cffa227a1075802c89a49dd4ce
@@ -406,6 +406,6 @@ SPEC CHECKSUMS:
   SSZipArchive: 62d4947b08730e4cda640473b0066d209ff033c9
   Yoga: 3ebccbdd559724312790e7742142d062476b698e
 
-PODFILE CHECKSUM: bc4542f17b8b63b9a76a81bc5630e50b4abfefc1
+PODFILE CHECKSUM: bcb1de0238d8679378c13c8969f0237df0241b07
 
 COCOAPODS: 1.10.1

--- a/example/package.json
+++ b/example/package.json
@@ -14,7 +14,7 @@
     "react-native-webview": "^11.2.4",
     "react-native-safe-area-context": "^3.2.0",
     "react-native-localize": "^2.0.2",
-    "mapwize-sdk-react-native": "^1.1.1",
+    "mapwize-sdk-react-native": "^1.1.2",
     "react-native-canvas": "^0.1.37"
   },
   "devDependencies": {

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -2673,10 +2673,10 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-mapwize-sdk-react-native@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/mapwize-sdk-react-native/-/mapwize-sdk-react-native-1.1.1.tgz#2c7c98bd6c022c9b31bc1117b8cf304a6fc0f02d"
-  integrity sha512-wYMOW0vQYpcqFWrdx1kln2h9srhIY35wX9xc0Kl+GPl5whM4EwfWMOLjJXd49tQ3iG750Y9qYqfXEJU7OQEz5w==
+mapwize-sdk-react-native@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/mapwize-sdk-react-native/-/mapwize-sdk-react-native-1.1.2.tgz#eac2144749d4af653d4e98aef0c29a2a8a2e0262"
+  integrity sha512-j8o7iJpNLpbmtvIwwjDGWs3Cj0jREod7sdRtxjF1kUIQMGAmMM0L1L2Cles8tj/sxxVGlAPN11W1E3mXkgcKTQ==
 
 merge-stream@^1.0.1:
   version "1.0.1"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "react-native-webview": "^11.2.4",
     "react-native-safe-area-context": "^3.2.0",
     "react-native-localize": "^2.0.2",
-    "mapwize-sdk-react-native": "^1.1.1",
+    "mapwize-sdk-react-native": "^1.1.2",
     "react-native-canvas": "^0.1.37"
   },
   "dependencies": {
@@ -82,7 +82,7 @@
     "react-native-webview": "^11.2.4",
     "react-native-safe-area-context": "^3.2.0",
     "react-native-localize": "^2.0.2",
-    "mapwize-sdk-react-native": "^1.1.1",
+    "mapwize-sdk-react-native": "^1.1.2",
     "react-native-canvas": "^0.1.37"
   },
   "jest": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6709,10 +6709,10 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-mapwize-sdk-react-native@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/mapwize-sdk-react-native/-/mapwize-sdk-react-native-1.1.1.tgz#2c7c98bd6c022c9b31bc1117b8cf304a6fc0f02d"
-  integrity sha512-wYMOW0vQYpcqFWrdx1kln2h9srhIY35wX9xc0Kl+GPl5whM4EwfWMOLjJXd49tQ3iG750Y9qYqfXEJU7OQEz5w==
+mapwize-sdk-react-native@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/mapwize-sdk-react-native/-/mapwize-sdk-react-native-1.1.2.tgz#eac2144749d4af653d4e98aef0c29a2a8a2e0262"
+  integrity sha512-j8o7iJpNLpbmtvIwwjDGWs3Cj0jREod7sdRtxjF1kUIQMGAmMM0L1L2Cles8tj/sxxVGlAPN11W1E3mXkgcKTQ==
 
 marked@^1.1.1:
   version "1.2.9"


### PR DESCRIPTION
- Updating mapwize-sdk-react-native to `1.1.2`. This fixes an error when building with the latest xcode version.